### PR TITLE
Attach items to item set when item set is already present

### DIFF
--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -123,6 +123,9 @@ class Import extends AbstractJob
                                                     'omekaimport_records',
                                                     $collectionImportRecord->id(),
                                                     $collectionImportRecordJson);
+
+                    $itemSetId = $collectionImportRecord->itemSet()->id();
+                    $options['collectionItemSet'] = $itemSetId;
                 } else {
                     $itemSetJson = $this->buildResourceJson($collectionData, $options);
                     $response = $this->api->create('item_sets', $itemSetJson);

--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -124,8 +124,10 @@ class Import extends AbstractJob
                                                     $collectionImportRecord->id(),
                                                     $collectionImportRecordJson);
 
-                    $itemSetId = $collectionImportRecord->itemSet()->id();
-                    $options['collectionItemSet'] = $itemSetId;
+                    $itemSet = $collectionImportRecord->itemSet();
+                    if ($itemSet) {
+                        $options['collectionItemSet'] = $itemSet->id();
+                    }
                 } else {
                     $itemSetJson = $this->buildResourceJson($collectionData, $options);
                     $response = $this->api->create('item_sets', $itemSetJson);


### PR DESCRIPTION
If there are new items in a previously imported collection and we try to
import them, they should be attached to the corresponding item set
