### PR TITLE
use the original_filename as o:source

### DIFF
--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -360,7 +360,7 @@ class Import extends AbstractJob
         foreach ($filesData as $fileData) {
             $fileJson = [
                 'o:ingester' => 'url',
-                'o:source' => $fileData['file_urls']['original'],
+                'o:source' => $fileData['original_filename'],
                 'ingest_url' => $fileData['file_urls']['original'],
             ];
             $fileJson = array_merge($fileJson, $this->buildPropertyJson($fileData));


### PR DESCRIPTION
Instead of having, in omeka-s a list of http://XXX associated with an item, reuse the original_filename which can be meaningful.