### PR TITLE
Do not fetch files while importing collections

### DIFF
--- a/src/Job/Import.php
+++ b/src/Job/Import.php
@@ -337,9 +337,12 @@ class Import extends AbstractJob
         $resourceJson['o:resource_class'] = ['o:id' => $resourceClassId];
         $resourceJson['o:resource_template'] = ['o:id' => $resourceTemplateId];
         $resourceJson = array_merge($resourceJson, $this->buildPropertyJson($importData));
-        $mediaJson = $this->buildMediaJson($importData);
-        $mediaJson = $this->buildHtmlMediaJson($importData, $mediaJson);
-        $resourceJson = array_merge($resourceJson, $mediaJson);
+
+        if (isset($importData['files'])) {
+            $mediaJson = $this->buildMediaJson($importData);
+            $mediaJson = $this->buildHtmlMediaJson($importData, $mediaJson);
+            $resourceJson = array_merge($resourceJson, $mediaJson);
+        }
 
         foreach ($importerClasses as $importerClass) {
             $importer = new $importerClass($this->client, $this->getServiceLocator());


### PR DESCRIPTION
buildResourceJson is used for both collections and items, and always calls buildMediaJson, which will then make API requests to the files endpoint.
Those are useless as no media can be added to an item set. Similarly, buildHtmlMediaJson is useless in the context of item sets.

This patch ensure that those methods are called only for items.